### PR TITLE
updates for search back button and tests

### DIFF
--- a/Find&Register/Views/Search/Index.cshtml
+++ b/Find&Register/Views/Search/Index.cshtml
@@ -45,11 +45,19 @@
             source: countries,
             defaultValue: '@Model.Area3'
         });
+
+        const backButton = document.getElementById("backButton");
+        if (backButton) {
+          backButton.addEventListener("click", function (e) {
+            e.preventDefault();
+            history.back();
+          });
+        }
     });
     </script>
 <div class="govuk-width-container govuk-body">
     <div role="navigation" aria-label="navigate back">
-        <a onclick="window.history.back()" class="govuk-back-link">Back</a>
+        <a href="#" id="backButton" class="govuk-back-link">Back</a>
     </div>
     <main class="govuk-main-wrapper">
         <div class="govuk-grid-row">

--- a/FindAndRegisterIntegrationTests/SearchJourneyTests.cs
+++ b/FindAndRegisterIntegrationTests/SearchJourneyTests.cs
@@ -5,6 +5,7 @@ using OpenQA.Selenium.Chrome;
 using Deque.AxeCore.Selenium;
 using System.Text;
 using Microsoft.AspNetCore.Mvc;
+using OpenQA.Selenium.Interactions;
 
 namespace FindAndRegisterIntegrationTests
 {
@@ -35,6 +36,20 @@ namespace FindAndRegisterIntegrationTests
             driver.Navigate().GoToUrl(Host);
 
             DoGDSTestsOnSearchPage(driver);
+        }
+
+        [Fact]
+        [Trait("Selenium", "Smoke")]
+        public void SearchJourneyBackButtonRedirectsToPreviousPag()
+        {
+            using IWebDriver driver = new ChromeDriver();
+            var actions = new Actions(driver);
+
+            driver.Navigate().GoToUrl("https://www.google.com/");
+            actions.ScrollByAmount(0, 1000);
+            driver.Navigate().GoToUrl(Host);
+            driver.FindElement(By.ClassName("govuk-back-link")).Click();
+            Assert.Equal("https://www.google.com/", driver.Url);
         }
 
         [Theory]

--- a/azure-pipelines-build.yml
+++ b/azure-pipelines-build.yml
@@ -28,7 +28,7 @@ parameters:
 variables:
   buildMajor: 2
   buildMinor: 0
-  buildPatch: 2
+  buildPatch: 3
   buildBranch: $[replace(replace(variables['Build.SourceBranch'], 'refs/heads/', ''), '/', '.')]
   identifier: he_ahofr
 


### PR DESCRIPTION
Once user click on back button then they will be navigated to the previous page they visited. 
page 1: we visit Google
![image](https://github.com/user-attachments/assets/436173af-14b0-4ce2-b266-1ec4046cdb72)
page 2: then we navigate to search page
![image](https://github.com/user-attachments/assets/69d976d3-75b4-40a9-a2d9-adca9633f5fa)
Once we click on "Back" button we expect to see the "Google" page. 

on the other hand, if we visit the search page and then we search something and get the result and then click on back button, we should see the search page again. This time if we click on back button, we expect to see the result page again. 
