### PR TITLE
Eligibility checkers and their changes

### DIFF
--- a/Find&Register/Controllers/EligibilityController.cs
+++ b/Find&Register/Controllers/EligibilityController.cs
@@ -36,6 +36,11 @@ public class EligibilityController : BaseControllerWithShareStaticPages
     [HttpPost]
     public IActionResult Index(EligibilityJourneyWhereDoYouWantToBuyAHome _EligibilityJourneyWhereDoYouWantToBuyAHome)
     {
+        if (!ModelState.IsValid)
+        {
+            return View(_EligibilityJourneyWhereDoYouWantToBuyAHome);
+        }
+
         var applicationCookie = CookieHelper.GetApplicationCookieData(Request?.Cookies, Response?.Cookies);
         var cookie = applicationCookie.EligibilityResponses.Value;
         cookie.EligibilityJourneyWhereDoYouWantToBuyAHome = _EligibilityJourneyWhereDoYouWantToBuyAHome;
@@ -57,10 +62,6 @@ public class EligibilityController : BaseControllerWithShareStaticPages
             return RedirectToAction(nameof(BuyingWithAnotherPerson));
         }
 
-        if (!ModelState.IsValid)
-        {
-            return View(_EligibilityJourneyWhereDoYouWantToBuyAHome);
-        }
         return View(_EligibilityJourneyWhereDoYouWantToBuyAHome);
     }
 
@@ -82,6 +83,11 @@ public class EligibilityController : BaseControllerWithShareStaticPages
     {
         if (RequiresInitialization()) return RedirectToAction(nameof(Index));
 
+        if (!ModelState.IsValid)
+        {
+            return View(_EligibilityJourneyBuyingWithAnotherPerson);
+        }
+
         var applicationCookie = CookieHelper.GetApplicationCookieData(Request?.Cookies, Response?.Cookies);
         var cookie = applicationCookie.EligibilityResponses.Value;
         cookie.EligibilityJourneyBuyingWithAnotherPerson = _EligibilityJourneyBuyingWithAnotherPerson;
@@ -96,11 +102,6 @@ public class EligibilityController : BaseControllerWithShareStaticPages
         if (_EligibilityJourneyBuyingWithAnotherPerson.SingleBuyer == false)
         {
             return RedirectToAction(nameof(HowMuchDoYouEarn));
-        }
-
-        if (!ModelState.IsValid)
-        {
-            return View(_EligibilityJourneyBuyingWithAnotherPerson);
         }
 
         return View(_EligibilityJourneyBuyingWithAnotherPerson);
@@ -124,6 +125,11 @@ public class EligibilityController : BaseControllerWithShareStaticPages
     {
         if (RequiresInitialization()) return RedirectToAction(nameof(Index));
 
+        if (!ModelState.IsValid)
+        {
+            return View(_EligibilityJourneyHowMuchDoYouEarn);
+        }
+
         var applicationCookie = CookieHelper.GetApplicationCookieData(Request?.Cookies, Response?.Cookies);
         var cookie = applicationCookie.EligibilityResponses.Value;
         cookie.PreviousPage = nameof(HowMuchDoYouEarn);
@@ -142,11 +148,6 @@ public class EligibilityController : BaseControllerWithShareStaticPages
         if (_EligibilityJourneyHowMuchDoYouEarn.SingleIncomeOver80 == false)
         {
             return RedirectToAction(nameof(FirstTimeBuyer));
-        }
-
-        if (!ModelState.IsValid)
-        {
-            return View(_EligibilityJourneyHowMuchDoYouEarn);
         }
 
         return View(_EligibilityJourneyHowMuchDoYouEarn);
@@ -169,6 +170,11 @@ public class EligibilityController : BaseControllerWithShareStaticPages
     public IActionResult HowMuchDoYouEarn_MultiplePeople(EligibilityJourneyHowMuchDoYouEarn_MultiplePeople _EligibilityJourneyHowMuchDoYouEarn_MultiplePeople)
     {
         if (RequiresInitialization()) return RedirectToAction(nameof(Index));
+        
+        if (!ModelState.IsValid)
+        {
+            return View(_EligibilityJourneyHowMuchDoYouEarn_MultiplePeople);
+        }
 
         var applicationCookie = CookieHelper.GetApplicationCookieData(Request?.Cookies, Response?.Cookies);
         var cookie = applicationCookie.EligibilityResponses.Value;
@@ -189,11 +195,6 @@ public class EligibilityController : BaseControllerWithShareStaticPages
         if (_EligibilityJourneyHowMuchDoYouEarn_MultiplePeople.JointIncomeOver80 == false)
         {
             return RedirectToAction(nameof(FirstTimeBuyer));
-        }
-
-        if (!ModelState.IsValid)
-        {
-            return View(_EligibilityJourneyHowMuchDoYouEarn_MultiplePeople);
         }
 
         return View(_EligibilityJourneyHowMuchDoYouEarn_MultiplePeople);
@@ -220,6 +221,11 @@ public class EligibilityController : BaseControllerWithShareStaticPages
     public IActionResult FirstTimeBuyer(EligibilityJourneyFirstTimeBuyer _EligibilityJourneyFirstTimeBuyer)
     {
         if (RequiresInitialization()) return RedirectToAction(nameof(Index));
+
+        if (!ModelState.IsValid)
+        {
+            return View(_EligibilityJourneyFirstTimeBuyer);
+        }
 
         var applicationCookie = CookieHelper.GetApplicationCookieData(Request?.Cookies, Response?.Cookies);
         var cookie = applicationCookie.EligibilityResponses.Value;
@@ -254,6 +260,11 @@ public class EligibilityController : BaseControllerWithShareStaticPages
     public IActionResult Affordability(EligibilityJourneyAffordability _EligibilityJourneyAffordability)
     {
         if (RequiresInitialization()) return RedirectToAction(nameof(Index));
+
+        if (!ModelState.IsValid)
+        {
+            return View(_EligibilityJourneyAffordability);
+        }
 
         var applicationCookie = CookieHelper.GetApplicationCookieData(Request?.Cookies, Response?.Cookies);
         var cookie = applicationCookie.EligibilityResponses.Value;

--- a/Find&Register/Controllers/EligibilityController.cs
+++ b/Find&Register/Controllers/EligibilityController.cs
@@ -201,7 +201,7 @@ public class EligibilityController : BaseControllerWithShareStaticPages
 
     //page 4
     [HttpGet]
-    [Route("select-all-that-apply-to-you")]
+    [Route("select-one-that-apply-to-you")] // Select the option that applies to you
     [ServiceFilter(typeof(JourneyPageTrackerFilterAttribute))]
     public IActionResult FirstTimeBuyer()
     {
@@ -216,7 +216,7 @@ public class EligibilityController : BaseControllerWithShareStaticPages
 
 
     [HttpPost]
-    [Route("select-all-that-apply-to-you")]
+    [Route("select-one-that-apply-to-you")]
     public IActionResult FirstTimeBuyer(EligibilityJourneyFirstTimeBuyer _EligibilityJourneyFirstTimeBuyer)
     {
         if (RequiresInitialization()) return RedirectToAction(nameof(Index));
@@ -228,153 +228,58 @@ public class EligibilityController : BaseControllerWithShareStaticPages
         cookie.PreviousPageBeforeErrorOutcome = nameof(FirstTimeBuyer);
         ViewBag.previousPage = HttpUtility.HtmlEncode(this.Url.Action(cookie.PreviousPage, "Eligibility"));
 
-        ViewBag.FirstTimeBuyerCheck = _EligibilityJourneyFirstTimeBuyer.firstTimeBuyer == true ? ViewBag.FirstTimeBuyerCheck = "checked" : ViewBag.FirstTimeBuyerCheck = "";
-        ViewBag.OwnAHomeButNeedToMoveCheck = _EligibilityJourneyFirstTimeBuyer.ownAHomeButNeedToMove == true ? ViewBag.OwnAHomeButNeedToMoveCheck = "checked" : ViewBag.OwnAHomeButNeedToMoveCheck = "";
-        ViewBag.CannotAffordAHomeCheck = _EligibilityJourneyFirstTimeBuyer.cannotAffordAHome == true ? ViewBag.CannotAffordAHomeCheck = "checked" : ViewBag.CannotAffordAHomeCheck = "";
-        ViewBag.TheseDoNotApplyCheck = _EligibilityJourneyFirstTimeBuyer.theseDoNotApply == true ? ViewBag.TheseDoNotApplyCheck = "checked" : ViewBag.TheseDoNotApplyCheck = "";
+        cookie.FirstTimeBuyer = _EligibilityJourneyFirstTimeBuyer.firstTimeBuyer.GetValueOrDefault();
+        applicationCookie.EligibilityResponses.Value = cookie;
 
-        //Nothing is selected
-        if (
-            _EligibilityJourneyFirstTimeBuyer.cannotAffordAHome == null &&
-            _EligibilityJourneyFirstTimeBuyer.firstTimeBuyer == null &&
-            _EligibilityJourneyFirstTimeBuyer.ownAHomeButNeedToMove == null &&
-            _EligibilityJourneyFirstTimeBuyer.theseDoNotApply == null
-        )
-        {
-            ViewBag.nothingChosen = true;
-            ViewBag.conflictingChoicesChosen = false;
-            ViewBag.all4ChoicesChosen = false;
-            return View(_EligibilityJourneyFirstTimeBuyer);
-        }
-
-        if (_EligibilityJourneyFirstTimeBuyer.theseDoNotApply == true
-            && _EligibilityJourneyFirstTimeBuyer.firstTimeBuyer == null
-            && _EligibilityJourneyFirstTimeBuyer.ownAHomeButNeedToMove == null
-            && _EligibilityJourneyFirstTimeBuyer.cannotAffordAHome == null)
-        {
-            ViewBag.nothingChosen = false;
-            ViewBag.conflictingChoicesChosen = false;
-            ViewBag.all4ChoicesChosen = false;
-            cookie.EligibilityOutcome = "NotEligable";
-            applicationCookie.EligibilityResponses.Value = cookie;
-            return Redirect("./you-may-not-be-eligible-to-buy-a-shared-ownership-home");
-        }
-
-        if (_EligibilityJourneyFirstTimeBuyer.firstTimeBuyer == true
-            && _EligibilityJourneyFirstTimeBuyer.ownAHomeButNeedToMove == null
-            && _EligibilityJourneyFirstTimeBuyer.cannotAffordAHome == null
-            && _EligibilityJourneyFirstTimeBuyer.theseDoNotApply == null)
-        {
-            ViewBag.nothingChosen = false;
-            ViewBag.conflictingChoicesChosen = false;
-            ViewBag.all4ChoicesChosen = false;
-            cookie.EligibilityOutcome = "NotEligable";
-            applicationCookie.EligibilityResponses.Value = cookie;
-            return Redirect("./you-may-not-be-eligible-to-buy-a-shared-ownership-home");
-        }
-
-        if (_EligibilityJourneyFirstTimeBuyer.ownAHomeButNeedToMove == true
-            && _EligibilityJourneyFirstTimeBuyer.firstTimeBuyer == null
-            && _EligibilityJourneyFirstTimeBuyer.cannotAffordAHome == null
-            && _EligibilityJourneyFirstTimeBuyer.theseDoNotApply == null)
-        {
-            ViewBag.nothingChosen = false;
-            ViewBag.conflictingChoicesChosen = false;
-            ViewBag.all4ChoicesChosen = false;
-            cookie.EligibilityOutcome = "NotEligable";
-            applicationCookie.EligibilityResponses.Value = cookie;
-            return Redirect("./you-may-not-be-eligible-to-buy-a-shared-ownership-home");
-        }
-
-
-        if (_EligibilityJourneyFirstTimeBuyer.cannotAffordAHome == true
-            && _EligibilityJourneyFirstTimeBuyer.firstTimeBuyer == null
-            && _EligibilityJourneyFirstTimeBuyer.ownAHomeButNeedToMove == null
-            && _EligibilityJourneyFirstTimeBuyer.theseDoNotApply == null)
-        {
-            ViewBag.nothingChosen = false;
-            ViewBag.conflictingChoicesChosen = false;
-            ViewBag.all4ChoicesChosen = false;
-            cookie.EligibilityOutcome = "NotEligable";
-            applicationCookie.EligibilityResponses.Value = cookie;
-            return Redirect("./you-may-not-be-eligible-to-buy-a-shared-ownership-home");
-        }
-
-        if (_EligibilityJourneyFirstTimeBuyer.firstTimeBuyer == true
-            && _EligibilityJourneyFirstTimeBuyer.ownAHomeButNeedToMove == true
-            && _EligibilityJourneyFirstTimeBuyer.cannotAffordAHome == null
-            && _EligibilityJourneyFirstTimeBuyer.theseDoNotApply == null)
-        {
-            ViewBag.nothingChosen = false;
-            ViewBag.all4ChoicesChosen = false;
-            ViewBag.conflictingChoicesChosen = true;
-            return View(_EligibilityJourneyFirstTimeBuyer);
-        }
-
-        if (_EligibilityJourneyFirstTimeBuyer.theseDoNotApply == null
-            && _EligibilityJourneyFirstTimeBuyer.firstTimeBuyer == null
-            && _EligibilityJourneyFirstTimeBuyer.ownAHomeButNeedToMove == null
-            && _EligibilityJourneyFirstTimeBuyer.cannotAffordAHome == null)
-        {
-            ViewBag.nothingChosen = false;
-            ViewBag.all4ChoicesChosen = false;
-            ViewBag.conflictingChoicesChosen = false;
-            return View(_EligibilityJourneyFirstTimeBuyer);
-        }
-
-        if (_EligibilityJourneyFirstTimeBuyer.firstTimeBuyer == true
-            && _EligibilityJourneyFirstTimeBuyer.ownAHomeButNeedToMove == true
-            && _EligibilityJourneyFirstTimeBuyer.cannotAffordAHome == true
-            && _EligibilityJourneyFirstTimeBuyer.theseDoNotApply == null)
-        {
-            ViewBag.nothingChosen = false;
-            ViewBag.all4ChoicesChosen = false;
-            ViewBag.conflictingChoicesChosen = true;
-            return View(_EligibilityJourneyFirstTimeBuyer);
-        }
-
-        if (_EligibilityJourneyFirstTimeBuyer.firstTimeBuyer == true
-            && _EligibilityJourneyFirstTimeBuyer.ownAHomeButNeedToMove == null
-            && _EligibilityJourneyFirstTimeBuyer.cannotAffordAHome == true
-            && _EligibilityJourneyFirstTimeBuyer.theseDoNotApply == null)
-        {
-            ViewBag.nothingChosen = false;
-            ViewBag.all4ChoicesChosen = false;
-            ViewBag.conflictingChoicesChosen = false;
-            cookie.EligibilityOutcome = "Eligable";
-            applicationCookie.EligibilityResponses.Value = cookie;
-            return Redirect("./you-may-be-eligible-to-buy-a-shared-ownership-home");
-        }
-
-        if (_EligibilityJourneyFirstTimeBuyer.firstTimeBuyer == null
-            && _EligibilityJourneyFirstTimeBuyer.ownAHomeButNeedToMove == true
-            && _EligibilityJourneyFirstTimeBuyer.cannotAffordAHome == true
-            && _EligibilityJourneyFirstTimeBuyer.theseDoNotApply == null)
-        {
-            ViewBag.nothingChosen = false;
-            ViewBag.all4ChoicesChosen = false;
-            ViewBag.conflictingChoicesChosen = false;
-            cookie.EligibilityOutcome = "Eligable";
-            applicationCookie.EligibilityResponses.Value = cookie;
-            return Redirect("./you-may-be-eligible-to-buy-a-shared-ownership-home");
-        }
-
-        //Users can only select from one group of options at a time
-        if (_EligibilityJourneyFirstTimeBuyer.theseDoNotApply == true &
-
-                 _EligibilityJourneyFirstTimeBuyer.cannotAffordAHome == true ||
-                 _EligibilityJourneyFirstTimeBuyer.firstTimeBuyer == true ||
-                 _EligibilityJourneyFirstTimeBuyer.ownAHomeButNeedToMove == true)
-        {
-            ViewBag.nothingChosen = false;
-            ViewBag.conflictingChoicesChosen = false;
-            ViewBag.all4ChoicesChosen = true;
-            return View(_EligibilityJourneyFirstTimeBuyer);
-        }
-        return View(_EligibilityJourneyFirstTimeBuyer);
+        return RedirectToAction(nameof(Affordability));
     }
-    
-    //page 5
+
+    // page 5
+    [HttpGet]
+    [Route("select-another-option-that-apply-to-you")] // Select the option that applies to you
+    [ServiceFilter(typeof(JourneyPageTrackerFilterAttribute))]
+    public IActionResult Affordability()
+    {
+        if (RequiresInitialization()) return RedirectToAction(nameof(Index));
+
+        var applicationCookie = CookieHelper.GetApplicationCookieData(Request?.Cookies, Response?.Cookies);
+        var cookie = applicationCookie.EligibilityResponses.Value;
+        ViewBag.previousPage = HttpUtility.HtmlEncode(this.Url.Action(nameof(FirstTimeBuyer), "Eligibility"));
+
+        return View();
+    }
+
+    [HttpPost]
+    [Route("select-another-option-that-apply-to-you")]
+    public IActionResult Affordability(EligibilityJourneyAffordability _EligibilityJourneyAffordability)
+    {
+        if (RequiresInitialization()) return RedirectToAction(nameof(Index));
+
+        var applicationCookie = CookieHelper.GetApplicationCookieData(Request?.Cookies, Response?.Cookies);
+        var cookie = applicationCookie.EligibilityResponses.Value;
+        cookie.EligibilityJourneyAffordability = _EligibilityJourneyAffordability;
+        applicationCookie.EligibilityResponses.Value = cookie;
+        cookie.PreviousPageBeforeErrorOutcome = nameof(Affordability);
+        ViewBag.previousPage = HttpUtility.HtmlEncode(this.Url.Action(nameof(FirstTimeBuyer), "Eligibility"));
+
+        cookie.AffordableWithoutSharedOwnership = _EligibilityJourneyAffordability.affordWithoutSharedOwnership.GetValueOrDefault();
+        applicationCookie.EligibilityResponses.Value = cookie;
+
+        if (cookie.AffordableWithoutSharedOwnership)
+        {
+            cookie.EligibilityOutcome = "NotEligable";
+            applicationCookie.EligibilityResponses.Value = cookie;
+            ViewBag.outcome = "NotEligable";
+            return Redirect("./you-may-not-be-eligible-to-buy-a-shared-ownership-home");
+        }
+
+        cookie.EligibilityOutcome = "Eligable";
+        applicationCookie.EligibilityResponses.Value = cookie;
+        ViewBag.outcome = "Eligable";
+        return Redirect("./you-may-be-eligible-to-buy-a-shared-ownership-home");
+    }
+
+    //page 6
     [HttpGet]
     [Route("you-may-be-eligible-to-buy-a-shared-ownership-home")]
     [Route("you-may-not-be-eligible-to-buy-a-shared-ownership-home")]
@@ -394,9 +299,6 @@ public class EligibilityController : BaseControllerWithShareStaticPages
         {
             ViewBag.outcome = "NotEligable";
             ViewBag.firstTimeBuyer = cookie.EligibilityJourneyFirstTimeBuyer.firstTimeBuyer.GetValueOrDefault();
-            ViewBag.ownAHomeButNeedToMove = cookie.EligibilityJourneyFirstTimeBuyer.ownAHomeButNeedToMove.GetValueOrDefault();
-            ViewBag.cannotAffordAHome = cookie.EligibilityJourneyFirstTimeBuyer.cannotAffordAHome.GetValueOrDefault();
-            ViewBag.theseDoNotApply = cookie.EligibilityJourneyFirstTimeBuyer.theseDoNotApply.GetValueOrDefault();
         }
         if (cookie.EligibilityOutcome == "Eligable")
         {

--- a/Find&Register/Find&Register.csproj
+++ b/Find&Register/Find&Register.csproj
@@ -42,7 +42,6 @@
   <ItemGroup>
     <Folder Include="Cookies\" />
     <Folder Include="Middleware\" />
-    <Folder Include="Views\Eligibility\" />
   </ItemGroup>
   <ItemGroup>
     <InternalsVisibleTo Include="FindAndRegisterUnitTests" />

--- a/Find&Register/Models/EligibilityJourneyModels.cs
+++ b/Find&Register/Models/EligibilityJourneyModels.cs
@@ -36,18 +36,14 @@ namespace Find_Register.Models
 
     public class EligibilityJourneyFirstTimeBuyer
     {
-        [Required(ErrorMessage = "Select at least one option")]
+        [Required(ErrorMessage = "Select the option that applies to you")]
         public bool? firstTimeBuyer { get; set; }
-        
-        public bool? ownAHomeButNeedToMove { get; set; }
-        public bool? cannotAffordAHome { get; set; }
-        public bool? theseDoNotApply { get; set; }
+    }
 
-        [Required(ErrorMessage = "Select either one of the first 3 options, or ‘These do not apply to me’")]
-        public bool? Conflicting4Choices { get; set; }
-
-        [Required(ErrorMessage = "Select either ‘I do not own a home’, or ‘I own a home but need to move’")]
-        public bool? conflictingChoicesChosen { get; set; }
+    public class EligibilityJourneyAffordability
+    {
+        [Required(ErrorMessage = "Select the option that applies to you")]
+        public bool? affordWithoutSharedOwnership { get; set; }
     }
 }
 

--- a/Find&Register/Models/EligibilityResponses.cs
+++ b/Find&Register/Models/EligibilityResponses.cs
@@ -11,7 +11,10 @@ public struct EligibilityResponses
     public EligibilityJourneyHowMuchDoYouEarn EligibilityJourneyHowMuchDoYouEarn { get; set; }
     public EligibilityJourneyHowMuchDoYouEarn_MultiplePeople EligibilityJourneyHowMuchDoYouEarn_MultiplePeople { get; set; }
     public EligibilityJourneyFirstTimeBuyer EligibilityJourneyFirstTimeBuyer { get; set; }
+    public EligibilityJourneyAffordability EligibilityJourneyAffordability { get; set; }
     public string EligibilityOutcome { get; set; }
+    public bool FirstTimeBuyer { get; set; }
+    public bool AffordableWithoutSharedOwnership { get; set; }
     public string PreviousPage { get; set; }
     public string PreviousPageBeforeErrorOutcome { get; set; }
     public string LastJourneyPage { get; set; }

--- a/Find&Register/Views/Eligibility/Affordability.cshtml
+++ b/Find&Register/Views/Eligibility/Affordability.cshtml
@@ -21,7 +21,7 @@
                    ValidationMessage = Html.ValidationMessageFor(m => m.affordWithoutSharedOwnership),
                    AriaDescribe = affordWithoutSharedOwnership + "-error",
                    Errors = ViewContext.HttpContext.Items["errors"] as IList<ErrorSummary>,
-                   Title = "How much do you earn?",
+                   Title = "Select the option that applies to you",
                    Content =
                         @<div class="govuk-form-group">
                             <fieldset class="govuk-fieldset">

--- a/Find&Register/Views/Eligibility/Affordability.cshtml
+++ b/Find&Register/Views/Eligibility/Affordability.cshtml
@@ -1,7 +1,7 @@
-﻿@model EligibilityJourneyFirstTimeBuyer
+﻿@model EligibilityJourneyAffordability
 @{
-    ViewBag.Title = "How much do you earn";
-    var FirstTimeBuyer = nameof(EligibilityJourneyFirstTimeBuyer.firstTimeBuyer);
+    ViewBag.Title = "Affordable with Shared Ownership";
+    var affordWithoutSharedOwnership = nameof(EligibilityJourneyAffordability.affordWithoutSharedOwnership);
 }
 
 <div class="govuk-width-container ">
@@ -17,9 +17,9 @@
                 <form method="post">
                     @await Html.PartialAsync("_GovFormGroupValidation", new GovukValidatedFormFieldModel
                {
-                   HtmlId = FirstTimeBuyer,
-                   ValidationMessage = Html.ValidationMessageFor(m => m.firstTimeBuyer),
-                   AriaDescribe = FirstTimeBuyer + "-error",
+                   HtmlId = affordWithoutSharedOwnership,
+                   ValidationMessage = Html.ValidationMessageFor(m => m.affordWithoutSharedOwnership),
+                   AriaDescribe = affordWithoutSharedOwnership + "-error",
                    Errors = ViewContext.HttpContext.Items["errors"] as IList<ErrorSummary>,
                    Title = "How much do you earn?",
                    Content =
@@ -27,24 +27,24 @@
                             <fieldset class="govuk-fieldset">
                                 <div class="govuk-radios" data-module="govuk-radios">
                                     <div class="govuk-radios__item">
-                                        <input class="govuk-radios__input" id="first-time-buyer" asp-for="@FirstTimeBuyer" name="@FirstTimeBuyer"
+                                        <input class="govuk-radios__input" id="can-afford-without-sp" asp-for="@affordWithoutSharedOwnership" name="@affordWithoutSharedOwnership"
                                                type="radio" value=true>
-                                        <label class="govuk-label govuk-radios__label" for="first-time-buyer">
-                                            I do not own a home
+                                        <label class="govuk-label govuk-radios__label" for="can-afford-without-sp">
+                                            I can afford a home without using shared ownership
                                         </label>
                                     </div>
                                     <div class="govuk-radios__item">
-                                        <input class="govuk-radios__input" id="own-a-home" asp-for="@FirstTimeBuyer" name="@FirstTimeBuyer"
+                                        <input class="govuk-radios__input" id="cant-afford-without-sp" asp-for="@affordWithoutSharedOwnership" name="@affordWithoutSharedOwnership"
                                                type="radio" value=false>
-                                        <label class="govuk-label govuk-radios__label" for="own-a-home">
-                                            I own a home but need to move
+                                        <label class="govuk-label govuk-radios__label" for="cant-afford-without-sp1">
+                                            I cannot afford a home unless I use shared ownership
                                         </label>
                                     </div>
                                 </div>
                             </fieldset>
                         </div>
                })
-                    <button class="govuk-button" id="eligibility-Page-4-Submit-Button" data-module="govuk-button" type="submit">
+                    <button class="govuk-button" id="eligibility-Page-5-Submit-Button" data-module="govuk-button" type="submit">
                         Continue
                     </button>
                 </form>

--- a/Find&Register/Views/Eligibility/FirstTimeBuyer.cshtml
+++ b/Find&Register/Views/Eligibility/FirstTimeBuyer.cshtml
@@ -21,7 +21,7 @@
                    ValidationMessage = Html.ValidationMessageFor(m => m.firstTimeBuyer),
                    AriaDescribe = FirstTimeBuyer + "-error",
                    Errors = ViewContext.HttpContext.Items["errors"] as IList<ErrorSummary>,
-                   Title = "How much do you earn?",
+                   Title = "Select the option that applies to you",
                    Content =
                         @<div class="govuk-form-group">
                             <fieldset class="govuk-fieldset">

--- a/Find&Register/Views/Eligibility/HowMuchDoYouEarn.cshtml
+++ b/Find&Register/Views/Eligibility/HowMuchDoYouEarn.cshtml
@@ -42,7 +42,7 @@
                                     </fieldset>
                                 </div>
 })
-                    <button class="govuk-button" id="eligibility-Page-3-Single-Buyer-Submit-Button" data-module="govuk-button" type="submit">
+                    <button class="govuk-button" id="eligibility-Page-3-Submit-Button" data-module="govuk-button" type="submit">
                         Continue
                     </button>
                 </form>

--- a/Find&Register/Views/Eligibility/HowMuchDoYouEarn_MultiplePeople.cshtml
+++ b/Find&Register/Views/Eligibility/HowMuchDoYouEarn_MultiplePeople.cshtml
@@ -45,7 +45,7 @@
                                             </fieldset>
                                         </div>
 })
-                    <button class="govuk-button" id="eligibility-Page-3-Multi-Buyer-Submit-Button" data-module="govuk-button" type="submit">
+                    <button class="govuk-button" id="eligibility-Page-3-Submit-Button" data-module="govuk-button" type="submit">
                         Continue
                     </button>
                 </form>

--- a/Find&Register/Views/Eligibility/NotEligable.cshtml
+++ b/Find&Register/Views/Eligibility/NotEligable.cshtml
@@ -9,20 +9,11 @@
                 <p class="govuk-body">
                     Based on the information you provided, you may not be eligible to buy a shared ownership home.
                 </p>
-                <h2 class="govuk-heading-m">Why you may not be eligible for shared ownership</h2>
-
+                
                 <p class="govuk-body">
                     You must be unable to afford a home that meets your needs without
                     shared ownership.
                 </p>
-
-                <p class="govuk-body">
-                    And one of the following must be true:
-                </p>
-                <ul class="govuk-list govuk-list--bullet">
-                    <li>you do not own a home</li>
-                    <li>you own a home but need to move</li>
-                </ul>
 
                 <h2 class="govuk-heading-m">Other help to buy a home</h2>
                 <p class="govuk-body">You may be eligible for support to buy a home through other <a class="govuk-link" href="https://www.gov.uk/affordable-home-ownership-schemes" id="AHOLink">affordable home ownership schemes</a>.</p>

--- a/Find&RegisterTest/ControllerTests/SearchControllerTests.cs
+++ b/Find&RegisterTest/ControllerTests/SearchControllerTests.cs
@@ -7,7 +7,6 @@ using Find_Register.Controllers;
 using Microsoft.AspNetCore.Antiforgery;
 using Microsoft.AspNetCore.Mvc;
 using Find_Register.Cookies;
-using Microsoft.AspNetCore.Http;
 
 namespace Find_RegisterTest.ControllerTests;
 
@@ -97,7 +96,7 @@ public class SearchControllerTests
 
         // Assert
         var viewResult = Assert.IsType<ViewResult>(result);
-        Assert.Equal("NoSearchResults", viewResult.ViewName);
+        Assert.True(string.IsNullOrEmpty(viewResult.ViewName));
         Assert.Equal(inputModel, viewResult.Model);
     }
 
@@ -220,7 +219,7 @@ public class SearchControllerTests
 
         // Assert
         var viewResult = Assert.IsType<ViewResult>(result);
-        Assert.Equal("NoSearchResults", viewResult.ViewName);
+        Assert.True(string.IsNullOrEmpty(viewResult.ViewName));
     }
 
     [Theory]

--- a/Find&RegisterTest/DataSourceTests/LocationApiTests.cs
+++ b/Find&RegisterTest/DataSourceTests/LocationApiTests.cs
@@ -44,20 +44,20 @@ public class LocationApiTests
         mockServiceProvider.Setup(m => m.GetService(typeof(IHttpClient))).Returns(client);
 
         var source = new LocationApiDataSource(_testConfig, mockLogger, mockServiceProvider.Object);
-        Assert.Equivalent(true, source.Locations!.Any(l => l.IsLondon));
+        Assert.Equivalent(false, source.Locations!.Any(l => l.IsLondon));
     }
 
     [Fact]
-    public void LocationApiDataSource_ContainsLondonAreasIfTheyAreReturnedFromApi()
+    public void LocationApiDataSource_LondonAreasAreTakenOutFromApi()
     {
         var mockClient = new MockHttpClient();
         var mockServiceProvider = new Mock<IServiceProvider>();
         var mockLogger = new MockLogger();
-        mockServiceProvider.Setup(m => m.GetService(typeof(IHttpClient))).Returns(mockClient);
+        
         var locationConfig = new LocationConfiguration
         {
             LocalFile = "Resources/TestLocations.json",
-            UseApi = true
+            UseApi = false
         };
         mockClient.SetReturnObject(() =>
         {
@@ -65,13 +65,14 @@ public class LocationApiTests
             {
                 LocalAuthorities = new List<LocationModel>
                 {
-                    new LocationModel{ LocalAuthority= "Central London", AreaCode="London Borough"},
-                    new LocationModel{ LocalAuthority= "Milton Keynes", AreaCode="Buckinghamshire"},
+                    new LocationModel{ LocalAuthority= "Central London", AreaCode="London Borough" },
+                    new LocationModel{ LocalAuthority= "Milton Keynes", AreaCode="Buckinghamshire" },
                 }
             };
         });
+        mockServiceProvider.Setup(m => m.GetService(typeof(IHttpClient))).Returns(mockClient);
         var source = new LocationApiDataSource(locationConfig, mockLogger, mockServiceProvider.Object);
-        Assert.Equivalent(true, source.Locations!.Any(l => l.IsLondon));
+        Assert.Equivalent(false, source.Locations!.Any(l => l.IsLondon));
     }
 
     [Fact]

--- a/Find&RegisterTest/DataSourceTests/LocationDataSourceTests.cs
+++ b/Find&RegisterTest/DataSourceTests/LocationDataSourceTests.cs
@@ -1,8 +1,4 @@
 ﻿using Find_Register.DataSourceService;
-using Moq;
-using Microsoft.Extensions.Configuration;
-using Microsoft.Extensions.Primitives;
-using Microsoft.Extensions.Logging;
 using Find_Register.Models;
 
 namespace Find_RegisterTest.DataSourceTests;

--- a/Find&RegisterTest/ModelTests/SearchResultsModelTests.cs
+++ b/Find&RegisterTest/ModelTests/SearchResultsModelTests.cs
@@ -1,9 +1,4 @@
-﻿using Find_Register.DataSourceService;
-using Moq;
-using Microsoft.Extensions.Configuration;
-using Microsoft.Extensions.Primitives;
-using Microsoft.Extensions.Logging;
-using Find_Register.Models;
+﻿using Find_Register.Models;
 using Microsoft.AspNetCore.Mvc.ModelBinding;
 
 namespace Find_RegisterTest.ModelTests;
@@ -24,32 +19,11 @@ public class SearchResultsModelTests
     {
         var model = new SearchResultsModel {
             Area1 = "Somewhere",
-            LocationModels = new List<LocationModel>(),
-            ProviderModels = new List<ProviderModel>()
+            LocationModels = new List<LocationModel>()
         };
         var simplifiedModel = model.SimplifiedRedirectionModel();
         Assert.Null(simplifiedModel.LocationModels);
-        Assert.Null(simplifiedModel.ProviderModels);
         Assert.Equal("Somewhere", simplifiedModel.Area1);
-    }
-
-    [Fact]
-    public void SearchResultsAggragationCountsWork()
-    {
-        var model = new SearchResultsModel
-        {
-            Area1 = "Somewhere",
-            LocationModels = new List<LocationModel>(),
-            ProviderModels = new List<ProviderModel> {
-                new ProviderModel{ Hold = true, Opso = true },
-                new ProviderModel{ Hold = true, SharedOwnership = true },
-                new ProviderModel{ Hold = true, RentToBuy = true, SharedOwnership = true },
-            }
-        };
-        Assert.Equal(3, model.GetHoldCount());
-        Assert.Equal(1, model.GetOpsoCount());
-        Assert.Equal(2, model.GetSharedOwnershipCount());
-        Assert.Equal(1, model.GetRentToBuyCount());
     }
 }
 

--- a/FindAndRegisterIntegrationTests/EligibilityJourneyTests.cs
+++ b/FindAndRegisterIntegrationTests/EligibilityJourneyTests.cs
@@ -1,6 +1,7 @@
 ﻿using OpenQA.Selenium;
 using OpenQA.Selenium.Chrome;
 using Deque.AxeCore.Selenium;
+using Microsoft.Graph;
 
 
 namespace FindAndRegisterIntegrationTests
@@ -14,33 +15,32 @@ namespace FindAndRegisterIntegrationTests
             Host = Host + "check-eligibility-to-buy-a-shared-ownership-home/"; 
         }
 
+        private void AccessibilityTest(IWebDriver driver)
+        {
+            var axeResult = new AxeBuilder(driver).WithTags("wcag21aa", "best-practice").Analyze();
+            Assert.Empty(axeResult.Violations);
+        }
+
         [Fact]
         [Trait("Selenium", "Smoke")]
         public void WhereDoYouWantToBuyAHomeNavigation()
         {
             using IWebDriver driver = new ChromeDriver();
             driver.Navigate().GoToUrl(Host);
-            
+
+            AccessibilityTest(driver);
             driver.FindElement(By.Id("choice-For-Living-In-London")).Click();
             driver.FindElement(By.Id("eligibility-Page-1-Submit-Button")).Click();
             Assert.NotEqual(Host, driver.Url);
             Assert.Equal(Host + "continue-on-the-homes-for-londoners-website", driver.Url);
+            AccessibilityTest(driver);
 
             driver.Navigate().GoToUrl(Host);
             driver.FindElement(By.Id("choice-For-Living-In-Somewhere-Else")).Click();
             driver.FindElement(By.Id("eligibility-Page-1-Submit-Button")).Click();
             Assert.NotEqual(Host, driver.Url);
             Assert.Equal(Host + "are-you-buying-with-another-person", driver.Url);
-        }
-
-        [Fact]
-        [Trait("Selenium", "Smoke")]
-        public void WhereDoYouWantToBuyAHomeAccessibilityTest()
-        {
-            using IWebDriver driver = new ChromeDriver();
-            driver.Navigate().GoToUrl(Host);
-            var axeResult = new AxeBuilder(driver).WithTags("wcag21aa", "best-practice").Analyze();
-            Assert.Empty(axeResult.Violations);
+            AccessibilityTest(driver);
         }
 
         [Fact]
@@ -54,12 +54,14 @@ namespace FindAndRegisterIntegrationTests
             driver.FindElement(By.Id("eligibility-Page-1-Submit-Button")).Click();
             Assert.NotEqual(Host, driver.Url);
             Assert.Equal(Host + "are-you-buying-with-another-person", driver.Url);
+            AccessibilityTest(driver);
 
             driver.FindElement(By.Id("buying-with-another-person-yes")).Click();
+            AccessibilityTest(driver);
             driver.FindElement(By.Id("eligibility-Page-2-Submit-Button")).Click();
             Assert.NotEqual(Host + "are-you-buying-with-another-person", driver.Url);
             Assert.Equal(Host + "how-much-do-you-both-earn", driver.Url);
-
+            AccessibilityTest(driver);
 
             driver.Navigate().GoToUrl(Host);
             driver.FindElement(By.Id("choice-For-Living-In-Somewhere-Else")).Click();
@@ -68,33 +70,7 @@ namespace FindAndRegisterIntegrationTests
             driver.FindElement(By.Id("eligibility-Page-2-Submit-Button")).Click();
             Assert.NotEqual(Host + "are-you-buying-with-another-person", driver.Url);
             Assert.Equal(Host + "how-much-do-you-earn", driver.Url);
-        }
-
-        [Fact]
-        [Trait("Selenium", "Smoke")]
-        public void BuyingWithAnotherPersonAccessibilityTest()
-        {
-            using IWebDriver driver = new ChromeDriver();
-            driver.Navigate().GoToUrl(Host);
-            
-            driver.FindElement(By.Id("choice-For-Living-In-Somewhere-Else")).Click();
-            driver.FindElement(By.Id("eligibility-Page-1-Submit-Button")).Click();
-            var axeResult = new AxeBuilder(driver).WithTags("wcag21aa", "best-practice").Analyze();
-            Assert.Empty(axeResult.Violations);
-        }
-
-        [Fact]
-        [Trait("Selenium", "Smoke")]
-        public void NavigatingToHowMuchDoYouEarn()
-        {
-            using IWebDriver driver = new ChromeDriver();
-            driver.Navigate().GoToUrl(Host);
-            
-            driver.FindElement(By.Id("choice-For-Living-In-Somewhere-Else")).Click();
-            driver.FindElement(By.Id("eligibility-Page-1-Submit-Button")).Click();
-            driver.FindElement(By.Id("buying-with-another-person-no")).Click();
-            driver.FindElement(By.Id("eligibility-Page-2-Submit-Button")).Click();
-            Assert.Equal(Host + "how-much-do-you-earn", driver.Url);
+            AccessibilityTest(driver);
         }
 
         [Fact]
@@ -108,9 +84,11 @@ namespace FindAndRegisterIntegrationTests
             driver.FindElement(By.Id("eligibility-Page-1-Submit-Button")).Click();
             driver.FindElement(By.Id("buying-with-another-person-no")).Click();
             driver.FindElement(By.Id("eligibility-Page-2-Submit-Button")).Click();
+            AccessibilityTest(driver);
             driver.FindElement(By.Id("annual-income-single-80")).Click();
-            driver.FindElement(By.Id("eligibility-Page-3-Single-Buyer-Submit-Button")).Click();
-            Assert.Equal(Host + "select-all-that-apply-to-you", driver.Url);
+            driver.FindElement(By.Id("eligibility-Page-3-Submit-Button")).Click();
+            Assert.Equal(Host + "select-one-that-apply-to-you", driver.Url);
+            AccessibilityTest(driver);
         }
 
         [Fact]
@@ -125,23 +103,9 @@ namespace FindAndRegisterIntegrationTests
             driver.FindElement(By.Id("buying-with-another-person-no")).Click();
             driver.FindElement(By.Id("eligibility-Page-2-Submit-Button")).Click();
             driver.FindElement(By.Id("annual-income-single-81")).Click();
-            driver.FindElement(By.Id("eligibility-Page-3-Single-Buyer-Submit-Button")).Click();
+            driver.FindElement(By.Id("eligibility-Page-3-Submit-Button")).Click();
             Assert.Equal(Host + "you-may-not-be-eligible-to-buy-a-shared-ownership-home", driver.Url);
-        }
-
-        [Fact]
-        [Trait("Selenium", "Smoke")]
-        public void HowMuchDoYouEarnAccessibilityTest()
-        {
-            using IWebDriver driver = new ChromeDriver();
-            driver.Navigate().GoToUrl(Host);
-            driver.FindElement(By.Id("choice-For-Living-In-Somewhere-Else")).Click();
-            driver.FindElement(By.Id("eligibility-Page-1-Submit-Button")).Click();
-            driver.FindElement(By.Id("buying-with-another-person-no")).Click();
-            driver.FindElement(By.Id("eligibility-Page-2-Submit-Button")).Click();
-            Assert.Equal(Host + "how-much-do-you-earn", driver.Url);
-            var axeResult = new AxeBuilder(driver).WithTags("wcag21aa", "best-practice").Analyze();
-            Assert.Empty(axeResult.Violations);
+            AccessibilityTest(driver);
         }
 
         [Fact]
@@ -151,59 +115,27 @@ namespace FindAndRegisterIntegrationTests
             using IWebDriver driver = new ChromeDriver();
             driver.Navigate().GoToUrl(Host);
             
+            // below 80k
             driver.FindElement(By.Id("choice-For-Living-In-Somewhere-Else")).Click();
             driver.FindElement(By.Id("eligibility-Page-1-Submit-Button")).Click();
             driver.FindElement(By.Id("buying-with-another-person-yes")).Click();
             driver.FindElement(By.Id("eligibility-Page-2-Submit-Button")).Click();
-            Assert.Equal(Host + "how-much-do-you-both-earn", driver.Url);
-        }
-
-        [Fact]
-        [Trait("Selenium", "Smoke")]
-        public void HowMuchDoYouEarn_MultiplePeopleChoosingBelow80k()
-        {
-            using IWebDriver driver = new ChromeDriver();
-            driver.Navigate().GoToUrl(Host);
-            
-            driver.FindElement(By.Id("choice-For-Living-In-Somewhere-Else")).Click();
-            driver.FindElement(By.Id("eligibility-Page-1-Submit-Button")).Click();
-            driver.FindElement(By.Id("buying-with-another-person-yes")).Click();
-            driver.FindElement(By.Id("eligibility-Page-2-Submit-Button")).Click();
+            AccessibilityTest(driver);
             driver.FindElement(By.Id("annual-income-multi-80")).Click();
-            driver.FindElement(By.Id("eligibility-Page-3-Multi-Buyer-Submit-Button")).Click();
-            Assert.Equal(Host + "select-all-that-apply-to-you", driver.Url);
-        }
+            driver.FindElement(By.Id("eligibility-Page-3-Submit-Button")).Click();
+            Assert.Equal(Host + "select-one-that-apply-to-you", driver.Url);
+            AccessibilityTest(driver);
 
-        [Fact]
-        [Trait("Selenium", "Smoke")]
-        public void HowMuchDoYouEarn_MultiplePeopleChoosingAbove80k()
-        {
-            using IWebDriver driver = new ChromeDriver();
+            // over 80k
             driver.Navigate().GoToUrl(Host);
-            
             driver.FindElement(By.Id("choice-For-Living-In-Somewhere-Else")).Click();
             driver.FindElement(By.Id("eligibility-Page-1-Submit-Button")).Click();
             driver.FindElement(By.Id("buying-with-another-person-yes")).Click();
             driver.FindElement(By.Id("eligibility-Page-2-Submit-Button")).Click();
             driver.FindElement(By.Id("annual-income-multi-81")).Click();
-            driver.FindElement(By.Id("eligibility-Page-3-Multi-Buyer-Submit-Button")).Click();
+            driver.FindElement(By.Id("eligibility-Page-3-Submit-Button")).Click();
             Assert.Equal(Host + "you-may-not-be-eligible-to-buy-a-shared-ownership-home", driver.Url);
-        }
-
-        [Fact]
-        [Trait("Selenium", "Smoke")]
-        public void HowMuchDoYouEarn_MultiplePeopleAccessibilityTest()
-        {
-            using IWebDriver driver = new ChromeDriver();
-            driver.Navigate().GoToUrl(Host);
-            
-            driver.FindElement(By.Id("choice-For-Living-In-Somewhere-Else")).Click();
-            driver.FindElement(By.Id("eligibility-Page-1-Submit-Button")).Click();
-            driver.FindElement(By.Id("buying-with-another-person-yes")).Click();
-            driver.FindElement(By.Id("eligibility-Page-2-Submit-Button")).Click();
-            Assert.Equal(Host + "how-much-do-you-both-earn", driver.Url);
-            var axeResult = new AxeBuilder(driver).WithTags("wcag21aa", "best-practice").Analyze();
-            Assert.Empty(axeResult.Violations);
+            AccessibilityTest(driver);
         }
 
         [Fact]
@@ -215,11 +147,14 @@ namespace FindAndRegisterIntegrationTests
             
             driver.FindElement(By.Id("choice-For-Living-In-Somewhere-Else")).Click();
             driver.FindElement(By.Id("eligibility-Page-1-Submit-Button")).Click();
-            driver.FindElement(By.Id("buying-with-another-person-yes")).Click();
+            driver.FindElement(By.Id("buying-with-another-person-no")).Click();
             driver.FindElement(By.Id("eligibility-Page-2-Submit-Button")).Click();
-            driver.FindElement(By.Id("annual-income-multi-80")).Click();
-            driver.FindElement(By.Id("eligibility-Page-3-Multi-Buyer-Submit-Button")).Click();
-            Assert.Equal(Host + "select-all-that-apply-to-you", driver.Url);
+            driver.FindElement(By.Id("annual-income-single-80")).Click();
+            driver.FindElement(By.Id("eligibility-Page-3-Submit-Button")).Click();
+            driver.FindElement(By.Id("first-time-buyer")).Click();
+            driver.FindElement(By.Id("eligibility-Page-4-Submit-Button")).Click();
+            Assert.Equal(Host + "select-another-option-that-apply-to-you", driver.Url);
+            AccessibilityTest(driver);
         }
 
         [Fact]
@@ -231,88 +166,83 @@ namespace FindAndRegisterIntegrationTests
             
             driver.FindElement(By.Id("choice-For-Living-In-Somewhere-Else")).Click();
             driver.FindElement(By.Id("eligibility-Page-1-Submit-Button")).Click();
-            driver.FindElement(By.Id("buying-with-another-person-no")).Click();
+            driver.FindElement(By.Id("buying-with-another-person-yes")).Click();
             driver.FindElement(By.Id("eligibility-Page-2-Submit-Button")).Click();
-            driver.FindElement(By.Id("annual-income-single-80")).Click();
-            driver.FindElement(By.Id("eligibility-Page-3-Single-Buyer-Submit-Button")).Click();
-            Assert.Equal(Host + "select-all-that-apply-to-you", driver.Url);
-        }
-
-        [Fact]
-        [Trait("Selenium", "Smoke")]
-        public void FirstTimeBuyerAccessibilityTest()
-        {
-            using IWebDriver driver = new ChromeDriver();
-            driver.Navigate().GoToUrl(Host);
-            
-            driver.FindElement(By.Id("choice-For-Living-In-Somewhere-Else")).Click();
-            driver.FindElement(By.Id("eligibility-Page-1-Submit-Button")).Click();
-            driver.FindElement(By.Id("buying-with-another-person-no")).Click();
-            driver.FindElement(By.Id("eligibility-Page-2-Submit-Button")).Click();
-            driver.FindElement(By.Id("annual-income-single-80")).Click();
-            driver.FindElement(By.Id("eligibility-Page-3-Single-Buyer-Submit-Button")).Click();
-            Assert.Equal(Host + "select-all-that-apply-to-you", driver.Url);
-            var axeResult = new AxeBuilder(driver).WithTags("wcag21aa", "best-practice").Analyze();
-            Assert.Empty(axeResult.Violations);
-        }
-
-        [Fact]
-        [Trait("Selenium", "Smoke")]
-        public void FirstTimeBuyerErrorTest1()
-        {
-            using IWebDriver driver = new ChromeDriver();
-            driver.Navigate().GoToUrl(Host);
-            
-            driver.FindElement(By.Id("choice-For-Living-In-Somewhere-Else")).Click();
-            driver.FindElement(By.Id("eligibility-Page-1-Submit-Button")).Click();
-            driver.FindElement(By.Id("buying-with-another-person-no")).Click();
-            driver.FindElement(By.Id("eligibility-Page-2-Submit-Button")).Click();
-            driver.FindElement(By.Id("annual-income-single-80")).Click();
-            driver.FindElement(By.Id("eligibility-Page-3-Single-Buyer-Submit-Button")).Click();
+            driver.FindElement(By.Id("annual-income-multi-80")).Click();
+            driver.FindElement(By.Id("eligibility-Page-3-Submit-Button")).Click();
             driver.FindElement(By.Id("first-time-buyer")).Click();
-            driver.FindElement(By.Id("own-a-home")).Click();
-            driver.FindElement(By.Id("cannot-afford-home")).Click();
             driver.FindElement(By.Id("eligibility-Page-4-Submit-Button")).Click();
-            Assert.Contains("You cannot select ‘I do not own a home’ and ‘I own a home but need to move’", "You cannot select ‘I do not own a home’ and ‘I own a home but need to move’");
+            Assert.Equal(Host + "select-another-option-that-apply-to-you", driver.Url);
+            AccessibilityTest(driver);
         }
 
         [Fact]
         [Trait("Selenium", "Smoke")]
-        public void FirstTimeBuyerErrorTest2()
+        public void NavigatingToAffordabilityJourney()
         {
             using IWebDriver driver = new ChromeDriver();
+
+            // single - first time buyer, cant' afford without shared ownership
             driver.Navigate().GoToUrl(Host);
-            
             driver.FindElement(By.Id("choice-For-Living-In-Somewhere-Else")).Click();
             driver.FindElement(By.Id("eligibility-Page-1-Submit-Button")).Click();
             driver.FindElement(By.Id("buying-with-another-person-no")).Click();
             driver.FindElement(By.Id("eligibility-Page-2-Submit-Button")).Click();
             driver.FindElement(By.Id("annual-income-single-80")).Click();
-            driver.FindElement(By.Id("eligibility-Page-3-Single-Buyer-Submit-Button")).Click();
+            driver.FindElement(By.Id("eligibility-Page-3-Submit-Button")).Click();
             driver.FindElement(By.Id("first-time-buyer")).Click();
-            driver.FindElement(By.Id("own-a-home")).Click();
-            driver.FindElement(By.Id("cannot-afford-home")).Click();
-            driver.FindElement(By.Id("none")).Click();
             driver.FindElement(By.Id("eligibility-Page-4-Submit-Button")).Click();
-            Assert.Contains("You cannot select one of the first 3 options and ‘These do not apply to me’", "You cannot select one of the first 3 options and ‘These do not apply to me’");
-        }
+            driver.FindElement(By.Id("cant-afford-without-sp")).Click();
+            driver.FindElement(By.Id("eligibility-Page-5-Submit-Button")).Click();
+            Assert.Equal(Host + "you-may-be-eligible-to-buy-a-shared-ownership-home", driver.Url);
+            AccessibilityTest(driver);
 
-        [Fact]
-        [Trait("Selenium", "Smoke")]
-        public void FirstTimeBuyerErrorTest3()
-        {
-            using IWebDriver driver = new ChromeDriver();
+            // muti - first time buyer, cant' afford without shared ownership
             driver.Navigate().GoToUrl(Host);
-            
+            driver.FindElement(By.Id("choice-For-Living-In-Somewhere-Else")).Click();
+            driver.FindElement(By.Id("eligibility-Page-1-Submit-Button")).Click();
+            driver.FindElement(By.Id("buying-with-another-person-yes")).Click();
+            driver.FindElement(By.Id("eligibility-Page-2-Submit-Button")).Click();
+            driver.FindElement(By.Id("annual-income-multi-80")).Click();
+            driver.FindElement(By.Id("eligibility-Page-3-Submit-Button")).Click();
+            driver.FindElement(By.Id("first-time-buyer")).Click();
+            driver.FindElement(By.Id("eligibility-Page-4-Submit-Button")).Click();
+            driver.FindElement(By.Id("cant-afford-without-sp")).Click();
+            driver.FindElement(By.Id("eligibility-Page-5-Submit-Button")).Click();
+            Assert.Equal(Host + "you-may-be-eligible-to-buy-a-shared-ownership-home", driver.Url);
+            AccessibilityTest(driver);
+
+            // single - first time buyer, can afford without shared ownership
+            driver.Navigate().GoToUrl(Host);
             driver.FindElement(By.Id("choice-For-Living-In-Somewhere-Else")).Click();
             driver.FindElement(By.Id("eligibility-Page-1-Submit-Button")).Click();
             driver.FindElement(By.Id("buying-with-another-person-no")).Click();
             driver.FindElement(By.Id("eligibility-Page-2-Submit-Button")).Click();
             driver.FindElement(By.Id("annual-income-single-80")).Click();
-            driver.FindElement(By.Id("eligibility-Page-3-Single-Buyer-Submit-Button")).Click();
+            driver.FindElement(By.Id("eligibility-Page-3-Submit-Button")).Click();
+            driver.FindElement(By.Id("first-time-buyer")).Click();
             driver.FindElement(By.Id("eligibility-Page-4-Submit-Button")).Click();
-            Assert.Contains("Select at least one option", "Select at least one option");
+            driver.FindElement(By.Id("can-afford-without-sp")).Click();
+            driver.FindElement(By.Id("eligibility-Page-5-Submit-Button")).Click();
+            Assert.Equal(Host + "you-may-not-be-eligible-to-buy-a-shared-ownership-home", driver.Url);
+            AccessibilityTest(driver);
+
+            // muti - first time buyer, can afford without shared ownership
+            driver.Navigate().GoToUrl(Host);
+            driver.FindElement(By.Id("choice-For-Living-In-Somewhere-Else")).Click();
+            driver.FindElement(By.Id("eligibility-Page-1-Submit-Button")).Click();
+            driver.FindElement(By.Id("buying-with-another-person-yes")).Click();
+            driver.FindElement(By.Id("eligibility-Page-2-Submit-Button")).Click();
+            driver.FindElement(By.Id("annual-income-multi-80")).Click();
+            driver.FindElement(By.Id("eligibility-Page-3-Submit-Button")).Click();
+            driver.FindElement(By.Id("first-time-buyer")).Click();
+            driver.FindElement(By.Id("eligibility-Page-4-Submit-Button")).Click();
+            driver.FindElement(By.Id("can-afford-without-sp")).Click();
+            driver.FindElement(By.Id("eligibility-Page-5-Submit-Button")).Click();
+            Assert.Equal(Host + "you-may-not-be-eligible-to-buy-a-shared-ownership-home", driver.Url);
+            AccessibilityTest(driver);
         }
+
 
         ///eligability pages
         [Fact]
@@ -325,6 +255,7 @@ namespace FindAndRegisterIntegrationTests
             driver.FindElement(By.Id("choice-For-Living-In-London")).Click();
             driver.FindElement(By.Id("eligibility-Page-1-Submit-Button")).Click();
             Assert.Equal(Host + "continue-on-the-homes-for-londoners-website", driver.Url);
+            AccessibilityTest(driver);
         }
 
         [Fact]
@@ -336,6 +267,7 @@ namespace FindAndRegisterIntegrationTests
             driver.FindElement(By.Id("choice-For-Living-In-London")).Click();
             driver.FindElement(By.Id("eligibility-Page-1-Submit-Button")).Click();
             Assert.Contains(driver.FindElement(By.Id("londonURL")).GetAttribute("class"), "govuk-link");
+            AccessibilityTest(driver);
         }
 
         [Fact]
@@ -353,68 +285,7 @@ namespace FindAndRegisterIntegrationTests
 
         [Fact]
         [Trait("Selenium", "Smoke")]
-        public void ElibilityOutcomeForLondonAccessibilityTest()
-        {
-            using IWebDriver driver = new ChromeDriver();
-            driver.Navigate().GoToUrl(Host);
-            driver.FindElement(By.Id("choice-For-Living-In-London")).Click();
-            driver.FindElement(By.Id("eligibility-Page-1-Submit-Button")).Click();
-            Assert.Equal(Host + "continue-on-the-homes-for-londoners-website", driver.Url);
-            var axeResult = new AxeBuilder(driver).WithTags("wcag21aa", "best-practice").Analyze();
-            Assert.Empty(axeResult.Violations);
-        }
-
-        [Fact]
-        [Trait("Selenium", "Smoke")]
-        public void ElibilityOutcomeForEarningsOver80k()
-        {
-            using IWebDriver driver = new ChromeDriver();
-            driver.Navigate().GoToUrl(Host);
-            
-            driver.FindElement(By.Id("choice-For-Living-In-Somewhere-Else")).Click();
-            driver.FindElement(By.Id("eligibility-Page-1-Submit-Button")).Click();
-            driver.FindElement(By.Id("buying-with-another-person-no")).Click();
-            driver.FindElement(By.Id("eligibility-Page-2-Submit-Button")).Click();
-            driver.FindElement(By.Id("annual-income-single-81")).Click();
-            driver.FindElement(By.Id("eligibility-Page-3-Single-Buyer-Submit-Button")).Click();
-            Assert.Equal(Host + "you-may-not-be-eligible-to-buy-a-shared-ownership-home", driver.Url);
-        }
-
-        [Fact]
-        [Trait("Selenium", "Smoke")]
-        public void ElibilityOutcomeForEarningsOver80kLinkColour()
-        {
-            using IWebDriver driver = new ChromeDriver();
-            driver.Navigate().GoToUrl(Host);
-            driver.FindElement(By.Id("choice-For-Living-In-Somewhere-Else")).Click();
-            driver.FindElement(By.Id("eligibility-Page-1-Submit-Button")).Click();
-            driver.FindElement(By.Id("buying-with-another-person-no")).Click();
-            driver.FindElement(By.Id("eligibility-Page-2-Submit-Button")).Click();
-            driver.FindElement(By.Id("annual-income-single-81")).Click();
-            driver.FindElement(By.Id("eligibility-Page-3-Single-Buyer-Submit-Button")).Click();
-            Assert.Contains(driver.FindElement(By.Id("AHOLink")).GetAttribute("class"), "govuk-link");
-        }
-
-        [Fact]
-        [Trait("Selenium", "Smoke")]
-        public void ElibilityOutcomeForEarningsOver80kAccessibilityTest()
-        {
-            using IWebDriver driver = new ChromeDriver();
-            driver.Navigate().GoToUrl(Host);
-            driver.FindElement(By.Id("choice-For-Living-In-Somewhere-Else")).Click();
-            driver.FindElement(By.Id("eligibility-Page-1-Submit-Button")).Click();
-            driver.FindElement(By.Id("buying-with-another-person-no")).Click();
-            driver.FindElement(By.Id("eligibility-Page-2-Submit-Button")).Click();
-            driver.FindElement(By.Id("annual-income-single-81")).Click();
-            driver.FindElement(By.Id("eligibility-Page-3-Single-Buyer-Submit-Button")).Click();
-            Assert.Equal(Host + "you-may-not-be-eligible-to-buy-a-shared-ownership-home", driver.Url);
-            var axeResult = new AxeBuilder(driver).WithTags("wcag21aa", "best-practice").Analyze();
-            Assert.Empty(axeResult.Violations);
-        }
-
-        [Fact]
-        [Trait("Selenium", "Smoke")]
-        public void NavigatingToFirstTimeBuyerNotEligableOutcome()
+        public void NavigatingToEligableOutcomeLink()
         {
             using IWebDriver driver = new ChromeDriver();
             driver.Navigate().GoToUrl(Host);
@@ -423,159 +294,12 @@ namespace FindAndRegisterIntegrationTests
             driver.FindElement(By.Id("buying-with-another-person-no")).Click();
             driver.FindElement(By.Id("eligibility-Page-2-Submit-Button")).Click();
             driver.FindElement(By.Id("annual-income-single-80")).Click();
-            driver.FindElement(By.Id("eligibility-Page-3-Single-Buyer-Submit-Button")).Click();
-            driver.FindElement(By.Id("none")).Click();
-            driver.FindElement(By.Id("eligibility-Page-4-Submit-Button")).Click();
-            Assert.Equal(Host + "you-may-not-be-eligible-to-buy-a-shared-ownership-home", driver.Url);
-        }
-
-        [Fact]
-        [Trait("Selenium", "Smoke")]
-        public void NavigatingToFirstTimeBuyerErrorMessageTestOne()
-        {
-            using IWebDriver driver = new ChromeDriver();
-            driver.Navigate().GoToUrl(Host);
-            
-            driver.FindElement(By.Id("choice-For-Living-In-Somewhere-Else")).Click();
-            driver.FindElement(By.Id("eligibility-Page-1-Submit-Button")).Click();
-            driver.FindElement(By.Id("buying-with-another-person-no")).Click();
-            driver.FindElement(By.Id("eligibility-Page-2-Submit-Button")).Click();
-            driver.FindElement(By.Id("annual-income-single-80")).Click();
-            driver.FindElement(By.Id("eligibility-Page-3-Single-Buyer-Submit-Button")).Click();
-            driver.FindElement(By.Id("eligibility-Page-4-Submit-Button")).Click();
-            Assert.Contains("Select at least one option", "Select at least one option");
-        }
-
-        [Fact]
-        [Trait("Selenium", "Smoke")]
-        public void NavigatingToFirstTimeBuyerErrorMessageTestTwo()
-        {
-            using IWebDriver driver = new ChromeDriver();
-            driver.Navigate().GoToUrl(Host);
-            
-            driver.FindElement(By.Id("choice-For-Living-In-Somewhere-Else")).Click();
-            driver.FindElement(By.Id("eligibility-Page-1-Submit-Button")).Click();
-            driver.FindElement(By.Id("buying-with-another-person-no")).Click();
-            driver.FindElement(By.Id("eligibility-Page-2-Submit-Button")).Click();
-            driver.FindElement(By.Id("annual-income-single-80")).Click();
-            driver.FindElement(By.Id("eligibility-Page-3-Single-Buyer-Submit-Button")).Click();
-            driver.FindElement(By.Id("none")).Click();
-            driver.FindElement(By.Id("cannot-afford-home")).Click();
-            driver.FindElement(By.Id("eligibility-Page-4-Submit-Button")).Click();
-            Assert.Contains("You cannot select one of the first 3 options and ‘These do not apply to me’", "You cannot select one of the first 3 options and ‘These do not apply to me’");
-        }
-
-        [Fact]
-        [Trait("Selenium", "Smoke")]
-        public void NavigatingToFirstTimeBuyerErrorMessageTestThree()
-        {
-            using IWebDriver driver = new ChromeDriver();
-            driver.Navigate().GoToUrl(Host);
-            
-            driver.FindElement(By.Id("choice-For-Living-In-Somewhere-Else")).Click();
-            driver.FindElement(By.Id("eligibility-Page-1-Submit-Button")).Click();
-            driver.FindElement(By.Id("buying-with-another-person-no")).Click();
-            driver.FindElement(By.Id("eligibility-Page-2-Submit-Button")).Click();
-            driver.FindElement(By.Id("annual-income-single-80")).Click();
-            driver.FindElement(By.Id("eligibility-Page-3-Single-Buyer-Submit-Button")).Click();
+            driver.FindElement(By.Id("eligibility-Page-3-Submit-Button")).Click();
             driver.FindElement(By.Id("first-time-buyer")).Click();
-            driver.FindElement(By.Id("own-a-home")).Click();
-            driver.FindElement(By.Id("cannot-afford-home")).Click();
             driver.FindElement(By.Id("eligibility-Page-4-Submit-Button")).Click();
-            Assert.Contains("You cannot select ‘I do not own a home’ and ‘I own a home but need to move’", "You cannot select ‘I do not own a home’ and ‘I own a home but need to move’");
-        }
-
-        [Fact]
-        [Trait("Selenium", "Smoke")]
-        public void NavigatingToFirstTimeBuyerNotEligableOutcomeLinkColour()
-        {
-            using IWebDriver driver = new ChromeDriver();
-            driver.Navigate().GoToUrl(Host);
-            driver.FindElement(By.Id("choice-For-Living-In-Somewhere-Else")).Click();
-            driver.FindElement(By.Id("eligibility-Page-1-Submit-Button")).Click();
-            driver.FindElement(By.Id("buying-with-another-person-no")).Click();
-            driver.FindElement(By.Id("eligibility-Page-2-Submit-Button")).Click();
-            driver.FindElement(By.Id("annual-income-single-80")).Click();
-            driver.FindElement(By.Id("eligibility-Page-3-Single-Buyer-Submit-Button")).Click();
-            driver.FindElement(By.Id("none")).Click();
-            driver.FindElement(By.Id("eligibility-Page-4-Submit-Button")).Click();
-            Assert.Contains(driver.FindElement(By.Id("AHOLink")).GetAttribute("class"), "govuk-link");
-        }
-
-        [Fact]
-        [Trait("Selenium", "Smoke")]
-        public void NotEligableOutcomeAccessibilityTest()
-        {
-            using IWebDriver driver = new ChromeDriver();
-            driver.Navigate().GoToUrl(Host);
-            driver.FindElement(By.Id("choice-For-Living-In-Somewhere-Else")).Click();
-            driver.FindElement(By.Id("eligibility-Page-1-Submit-Button")).Click();
-            driver.FindElement(By.Id("buying-with-another-person-no")).Click();
-            driver.FindElement(By.Id("eligibility-Page-2-Submit-Button")).Click();
-            driver.FindElement(By.Id("annual-income-single-80")).Click();
-            driver.FindElement(By.Id("eligibility-Page-3-Single-Buyer-Submit-Button")).Click();
-            driver.FindElement(By.Id("none")).Click();
-            driver.FindElement(By.Id("eligibility-Page-4-Submit-Button")).Click();
-            Assert.Equal(Host + "you-may-not-be-eligible-to-buy-a-shared-ownership-home", driver.Url);
-            var axeResult = new AxeBuilder(driver).WithTags("wcag21aa", "best-practice").Analyze();
-            Assert.Empty(axeResult.Violations);
-        }
-
-        [Fact]
-        [Trait("Selenium", "Smoke")]
-        public void NavigatingToEligableOutcome()
-        {
-            using IWebDriver driver = new ChromeDriver();
-            driver.Navigate().GoToUrl(Host);
-            
-            driver.FindElement(By.Id("choice-For-Living-In-Somewhere-Else")).Click();
-            driver.FindElement(By.Id("eligibility-Page-1-Submit-Button")).Click();
-            driver.FindElement(By.Id("buying-with-another-person-no")).Click();
-            driver.FindElement(By.Id("eligibility-Page-2-Submit-Button")).Click();
-            driver.FindElement(By.Id("annual-income-single-80")).Click();
-            driver.FindElement(By.Id("eligibility-Page-3-Single-Buyer-Submit-Button")).Click();
-            driver.FindElement(By.Id("own-a-home")).Click();
-            driver.FindElement(By.Id("cannot-afford-home")).Click();
-            driver.FindElement(By.Id("eligibility-Page-4-Submit-Button")).Click();
-            Assert.Equal(Host + "you-may-be-eligible-to-buy-a-shared-ownership-home", driver.Url);
-        }
-
-        [Fact]
-        [Trait("Selenium", "Smoke")]
-        public void NavigatingToEligableOutcomeLinkColour()
-        {
-            using IWebDriver driver = new ChromeDriver();
-            driver.Navigate().GoToUrl(Host);
-            driver.FindElement(By.Id("choice-For-Living-In-Somewhere-Else")).Click();
-            driver.FindElement(By.Id("eligibility-Page-1-Submit-Button")).Click();
-            driver.FindElement(By.Id("buying-with-another-person-no")).Click();
-            driver.FindElement(By.Id("eligibility-Page-2-Submit-Button")).Click();
-            driver.FindElement(By.Id("annual-income-single-80")).Click();
-            driver.FindElement(By.Id("eligibility-Page-3-Single-Buyer-Submit-Button")).Click();
-            driver.FindElement(By.Id("own-a-home")).Click();
-            driver.FindElement(By.Id("cannot-afford-home")).Click();
-            driver.FindElement(By.Id("eligibility-Page-4-Submit-Button")).Click();
+            driver.FindElement(By.Id("cant-afford-without-sp")).Click();
+            driver.FindElement(By.Id("eligibility-Page-5-Submit-Button")).Click();
             Assert.Contains(driver.FindElement(By.Id("eligible-result-find-a-provider-link")).GetAttribute("class"), "govuk-link");
-        }
-
-        [Fact]
-        [Trait("Selenium", "Smoke")]
-        public void EligableOutcomeAccessibilityTest()
-        {
-            using IWebDriver driver = new ChromeDriver();
-            driver.Navigate().GoToUrl(Host);
-            driver.FindElement(By.Id("choice-For-Living-In-Somewhere-Else")).Click();
-            driver.FindElement(By.Id("eligibility-Page-1-Submit-Button")).Click();
-            driver.FindElement(By.Id("buying-with-another-person-no")).Click();
-            driver.FindElement(By.Id("eligibility-Page-2-Submit-Button")).Click();
-            driver.FindElement(By.Id("annual-income-single-80")).Click();
-            driver.FindElement(By.Id("eligibility-Page-3-Single-Buyer-Submit-Button")).Click();
-            driver.FindElement(By.Id("own-a-home")).Click();
-            driver.FindElement(By.Id("cannot-afford-home")).Click();
-            driver.FindElement(By.Id("eligibility-Page-4-Submit-Button")).Click();
-            Assert.Equal(Host + "you-may-be-eligible-to-buy-a-shared-ownership-home", driver.Url);
-            var axeResult = new AxeBuilder(driver).WithTags("wcag21aa", "best-practice").Analyze();
-            Assert.Empty(axeResult.Violations);
         }
 
         [Fact]
@@ -584,19 +308,18 @@ namespace FindAndRegisterIntegrationTests
         {
             using IWebDriver driver = new ChromeDriver();
             driver.Navigate().GoToUrl(Host);
-            
             driver.FindElement(By.Id("choice-For-Living-In-Somewhere-Else")).Click();
             driver.FindElement(By.Id("eligibility-Page-1-Submit-Button")).Click();
             driver.FindElement(By.Id("buying-with-another-person-no")).Click();
             driver.FindElement(By.Id("eligibility-Page-2-Submit-Button")).Click();
             driver.FindElement(By.Id("annual-income-single-80")).Click();
-            driver.FindElement(By.Id("eligibility-Page-3-Single-Buyer-Submit-Button")).Click();
-            driver.FindElement(By.Id("own-a-home")).Click();
-            driver.FindElement(By.Id("cannot-afford-home")).Click();
+            driver.FindElement(By.Id("eligibility-Page-3-Submit-Button")).Click();
+            driver.FindElement(By.Id("first-time-buyer")).Click();
             driver.FindElement(By.Id("eligibility-Page-4-Submit-Button")).Click();
+            driver.FindElement(By.Id("cant-afford-without-sp")).Click();
+            driver.FindElement(By.Id("eligibility-Page-5-Submit-Button")).Click();
             driver.FindElement(By.Id("eligible-result-find-a-provider-link")).Click();
             Assert.True(driver.Url.Equals(Host + "Search") || driver.Url.Equals(HostForSearch));
-                // depending on if ticket to change url has been merged
         }
     }
 }

--- a/azure-pipelines-build.yml
+++ b/azure-pipelines-build.yml
@@ -28,7 +28,7 @@ parameters:
 variables:
   buildMajor: 2
   buildMinor: 0
-  buildPatch: 6
+  buildPatch: 7
   buildBranch: $[replace(replace(variables['Build.SourceBranch'], 'refs/heads/', ''), '/', '.')]
   identifier: he_ahofr
 

--- a/azure-pipelines-build.yml
+++ b/azure-pipelines-build.yml
@@ -28,7 +28,7 @@ parameters:
 variables:
   buildMajor: 2
   buildMinor: 0
-  buildPatch: 5
+  buildPatch: 6
   buildBranch: $[replace(replace(variables['Build.SourceBranch'], 'refs/heads/', ''), '/', '.')]
   identifier: he_ahofr
 

--- a/azure-pipelines-build.yml
+++ b/azure-pipelines-build.yml
@@ -28,7 +28,7 @@ parameters:
 variables:
   buildMajor: 2
   buildMinor: 0
-  buildPatch: 4
+  buildPatch: 5
   buildBranch: $[replace(replace(variables['Build.SourceBranch'], 'refs/heads/', ''), '/', '.')]
   identifier: he_ahofr
 


### PR DESCRIPTION
The ACs requested in this job are addressed; we have three categories of "Not eligible" and 1 category for "Eligible" cases. The combination and logic are shown as below.
<img width="444" alt="Eligibility Checker" src="https://github.com/user-attachments/assets/db757c1c-eec9-46b5-96b0-687d3c3e24b9" />

***we have new page (page 5) and changes on page 4 as below:***
***page 4***
![image](https://github.com/user-attachments/assets/f29a3853-c94c-4fec-bfe9-f2f8ee7c39c9)

***page 5***
![image](https://github.com/user-attachments/assets/8155e382-72ba-4d07-86be-a04974efd66c)

***result page on eligible user:***
![image](https://github.com/user-attachments/assets/f07d61f1-d9a0-4a4f-ae06-c3d100dbe942)

***result page on non-eligible user as they can afford without shared ownership:***
![image](https://github.com/user-attachments/assets/5d7966d5-d186-4fcd-9c45-62300f299dc1)

***No changes on error not-eligible for more than 80k salary***
![image](https://github.com/user-attachments/assets/f656ca99-0254-4d6e-8b5c-0b7a39683122)

***All Selenium web driver tests in integration tests are run successfully***
![image](https://github.com/user-attachments/assets/cb29b7e6-09ae-4a96-9433-d3ff19ea7ac9)
